### PR TITLE
Create README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# changelog-updater-example
+
+This repository demonstrates the [changelog updater](https://github.com/claudiodekker/changelog-updater) library, and it's [auto-updating Github Action](https://github.com/claudiodekker/changelog-updater-example/blob/master/.github/workflows/update_changelog.yml).
+
+To see how this works, take a look at [the commit history](https://github.com/claudiodekker/changelog-updater-example/commits/master) and the [closed pull requests](https://github.com/claudiodekker/changelog-updater-example/pulls?q=is%3Apr+is%3Aclosed).


### PR DESCRIPTION
This PR adds the Readme file, but won't be added to the changelog, because we haven't added any CHANGELOG-related labels. 

While I could've not added any labels, I'll add the `documentation` label simply to demonstrate that nothing will happen, since [our Github Action does not have any matching sections](https://github.com/claudiodekker/changelog-updater-example/blob/master/.github/workflows/update_changelog.yml#L32-L39) for it.