### PR TITLE
Changelog: Fix v1.0.0 release reference link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/claudiodekker/changelog-updater-example/compare/v0.1.0...HEAD)
+## [Unreleased](https://github.com/claudiodekker/changelog-updater-example/compare/v1.0.0...HEAD)
 
 ## [v1.0.0](https://github.com/claudiodekker/changelog-updater-example/releases/tag/v1.0.0) - 2023-04-11
 


### PR DESCRIPTION
This PR demonstrates a couple of things:

- Preservation of a custom "Unreleased" section
- Updating a CHANGELOG.md file that'll be updated directly after by the action
- Custom "descriptions" in a CHANGELOG (between the release title and sections) are preserved